### PR TITLE
Add multi-arch Docker support for ARM64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: davidemerli/swurapp:latest
+          tags: owlcaribou/swurapp:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Added multi-arch build support for AMD64 and ARM64 platforms. Needed this to run on my Raspberry Pi. Also added GitHub Actions cache for faster builds.