### PR TITLE
Make documented image name compatible with Podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker run -d \
   -e DELAY_IN_MINUTES=60 \
   -e IGNORE_TAG_NAME="ignore" \
   --restart unless-stopped \
-  owlcaribou/swurApp:latest
+  owlcaribou/swurapp:latest
 ```
 
 ### Option 2: Docker Compose


### PR DESCRIPTION
Apparently having non-lowercase repository URL is not entirely legal. Looks like Docker is more lenient in this, while Podman isn't

```
> podman run owlcaribou/swurApp:latest
Error: parsing reference "owlcaribou/swurApp:latest": repository name must be lowercase
```