### PR TITLE
Preserve multi-arch manifest when promoting :dev to :latest

### DIFF
--- a/.github/workflows/promote-latest.yml
+++ b/.github/workflows/promote-latest.yml
@@ -13,11 +13,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull dev image
-        run: docker pull owlcaribou/swurapp:dev
-
-      - name: Tag as latest
-        run: docker tag owlcaribou/swurapp:dev owlcaribou/swurapp:latest
-
-      - name: Push latest
-        run: docker push owlcaribou/swurapp:latest
+      # docker pull/tag/push collapses a multi-arch manifest list to the
+      # runner's architecture (amd64), dropping the arm64 image. imagetools
+      # copies the manifest list registry-side, keeping all platforms.
+      - name: Promote dev to latest
+        run: docker buildx imagetools create --tag owlcaribou/swurapp:latest owlcaribou/swurapp:dev


### PR DESCRIPTION
## Problem

`owlcaribou/swurapp:latest` is amd64-only, even though `:dev` contains both amd64
and arm64. The README points users at `:latest`, so anyone on ARM (Raspberry Pi,
ARM NAS, Apple Silicon) gets a "no matching manifest" error or a slow emulated
amd64 container. Bit of a follow up to #1 that I opened almost exactly a year ago ;)

To confirm:

    docker buildx imagetools inspect owlcaribou/swurapp:dev     # OCI index: amd64 + arm64
    docker buildx imagetools inspect owlcaribou/swurapp:latest  # single manifest: amd64 only

## Cause

The build is fine: `build.yml` still pushes both architectures to `:dev`. The
problem is in `promote-latest.yml`. `docker pull` resolves a multi-arch manifest
list to the runner's own architecture (amd64), so the later `docker tag` and
`docker push` publish `:latest` as a single-arch image and drop arm64.

## Fix

Promote with `docker buildx imagetools create` instead. It copies the manifest
list inside the registry by digest: nothing is pulled, all platforms are kept,
and `:latest` points at the same digests that were tested as `:dev`. No changes
to `build.yml` or `tests.yml`, and no new tooling, since buildx is preinstalled
on GitHub runners.

Tested against a local registry: promoting a multi-arch `:dev` with pull/tag/push
produced a single-arch `:latest`, while `imagetools create` produced a `:latest`
index identical to `:dev` (same digest, both platforms).

## After merging

This only fixes future promotions. Run the "Promote to Latest" workflow once
after merging to repair the current amd64-only `:latest` tag.